### PR TITLE
Feature: hide project tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated design for Project Edit page, buttons and other Quality of Life changes - [#128](https://github.com/DigitalExcellence/dex-frontend/pull/128)
 - Added more structure to styling & moved scss to specific files in the assets folder - [#122](https://github.com/DigitalExcellence/dex-frontend/issues/122)
 - Updated favicon to match branding & added favicon support for various platforms - [#145](https://github.com/DigitalExcellence/dex-frontend/issues/145)
-- Hidden project tags for production mode [#148](https://github.com/DigitalExcellence/dex-frontend/issues/148)
+- Hidden project tags for production mode - [#148](https://github.com/DigitalExcellence/dex-frontend/issues/148)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated design for Project Edit page, buttons and other Quality of Life changes - [#128](https://github.com/DigitalExcellence/dex-frontend/pull/128)
 - Added more structure to styling & moved scss to specific files in the assets folder - [#122](https://github.com/DigitalExcellence/dex-frontend/issues/122)
 - Updated favicon to match branding & added favicon support for various platforms - [#145](https://github.com/DigitalExcellence/dex-frontend/issues/145)
+- Hidden project tags for production mode [#148](https://github.com/DigitalExcellence/dex-frontend/issues/148)
 
 ### Deprecated
 

--- a/src/app/modules/project/details/details.component.html
+++ b/src/app/modules/project/details/details.component.html
@@ -50,25 +50,25 @@
     <div class="col-9">
       <h1 class="project-title">{{ project.name }}</h1>
       <div class="project-tags" [hidden]="!displayTags()">
-        <a class="project-tags__tag" href="#">
+        <a class="project-tags__tag" href="javascript:void(0)">
           Game
         </a>
-        <a class="project-tags__tag" href="#">
+        <a class="project-tags__tag" href="javascript:void(0)">
           JavaScript
         </a>
-        <a class="project-tags__tag" href="#">
+        <a class="project-tags__tag" href="javascript:void(0)">
           HTML
         </a>
-        <a class="project-tags__tag" href="#">
+        <a class="project-tags__tag" href="javascript:void(0)">
           CSS
         </a>
-        <a class="project-tags__tag" href="#">
+        <a class="project-tags__tag" href="javascript:void(0)">
           UX
         </a>
-        <a class="project-tags__tag" href="#">
+        <a class="project-tags__tag" href="javascript:void(0)">
           Interaction
         </a>
-        <a class="project-tags__see-more-link" href="#">
+        <a class="project-tags__see-more-link" href="javascript:void(0)">
           see more tags&hellip;
         </a>
       </div>

--- a/src/app/modules/project/details/details.component.html
+++ b/src/app/modules/project/details/details.component.html
@@ -49,7 +49,7 @@
     </div>
     <div class="col-9">
       <h1 class="project-title">{{ project.name }}</h1>
-      <div class="project-tags">
+      <div class="project-tags" [hidden]="!displayTags()">
         <a class="project-tags__tag" href="#">
           Game
         </a>

--- a/src/app/modules/project/details/details.component.ts
+++ b/src/app/modules/project/details/details.component.ts
@@ -1,3 +1,4 @@
+import { environment } from 'src/environments/environment';
 /*
  *  Digital Excellence Copyright (C) 2020 Brend Smits
  *
@@ -44,7 +45,7 @@ export class DetailsComponent implements OnInit {
     private projectService: ProjectService,
     private authService: AuthService,
     private highlightService: HighlightService
-  ) {}
+  ) { }
 
   ngOnInit(): void {
     const routeId = this.activedRoute.snapshot.paramMap.get('id');
@@ -79,6 +80,14 @@ export class DetailsComponent implements OnInit {
    */
   public onClickHighlightButton(): void {
     const hightlightAdd: HighlightAdd = { projectId: this.project.id, startDate: null, endDate: null };
-    this.highlightService.post(hightlightAdd).subscribe((result) => {});
+    this.highlightService.post(hightlightAdd).subscribe((result) => { });
+  }
+
+  /**
+   * Method to display the tags based on the environment variable.
+   * Tags should be hidden in production for now untill futher implementation is finished.
+   */
+  public displayTags(): boolean {
+    return !environment.production;
   }
 }


### PR DESCRIPTION
## Description

Implemented hiding of project tags for production. Since this is not fully implemented yet. Also fixed issue with the empty href on the tags causing unwanted redirects.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I did not update API Controllers, if I did, I added/changed Postman tests
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

1. Navigate to project overview
2. Click a project
3. If the production property of the environment variable is false the tag will be displayed, if true it will be displayed.

## Link to issue

Closes: #148
