### PR TITLE
Fixed wizard requests, URL not supported error and added message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed login button text to sign in for consistency - [#186](https://github.com/DigitalExcellence/dex-frontend/issues/186)
 - Changed the design of the "Add Project" page - [#188](https://github.com/DigitalExcellence/dex-frontend/issues/188)
 - Changed the project-add input and search inputs so you can now press the enter key to submit - [#224](https://github.com/DigitalExcellence/dex-frontend/issues/224)
+- Changed the wizard requests, fixed URL not supported error and added message - [#236](https://github.com/DigitalExcellence/dex-frontend/issues/236)
 
 ### Deprecated
 

--- a/src/app/interceptors/http.interceptor.ts
+++ b/src/app/interceptors/http.interceptor.ts
@@ -57,6 +57,7 @@ export class HttpErrorInterceptor implements HttpInterceptor {
      */
     private readonly ignoredEndpoints: IgnoredRequests[] = [
         { endpoint: 'highlight/project/', method: HttpMethods.GET },
+        { endpoint: 'wizard', method: HttpMethods.GET },
     ];
 
     constructor(


### PR DESCRIPTION
## Description
The PR fixes the missing requests to the back end to retrieve project metadata.
It also fixes the URL not supported error and it adds a message for the user to notify the user that we were not able to automagically retrieve metadata.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.
These steps will be used during release testing.

1. Go to 'Add project'
2. Add the URL 'https://github.com/DigitalExcellence'
3. Click on the search icon
4. The manual wizard will show with a message

## Link to issue

Closes: #236
