### PR TITLE
Bugfix/163 footer responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Changed
+
+- Changed all file line endings from CRLF to LF and added the .gitattributes to enforce it - [#163](https://github.com/DigitalExcellence/dex-backend/issues/163)
 - Changed footer.component.html and footer.component.scss for creating a responsive footer. - [#163] (https://github.com/DigitalExcellence/dex-frontend/issues/163) 
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed all file line endings from CRLF to LF and added the .gitattributes to enforce it - [#163](https://github.com/DigitalExcellence/dex-backend/issues/163)
-- Changed footer.component.html and footer.component.scss for creating a responsive footer. - [#163] (https://github.com/DigitalExcellence/dex-frontend/issues/163) 
+- Changed footer styling to be responsive on small screens - [#163] (https://github.com/DigitalExcellence/dex-frontend/issues/163) 
 
 ### Deprecated
 

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -54,7 +54,7 @@
       </div>
     </div>
     <div class="row justify-content-center">
-      <div class="col-3 copyright text-center">
+      <div class="col-6 copyright text-center">
         <p>Find <strong>DeX</strong> on <a class="github-link" href="https://github.com/DigitalExcellence" target="_blank" rel="noopener noreferrer"><strong>GitHub</strong></a></p>
       </div>
     </div>

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -23,14 +23,14 @@
       <div class="col-lg-3 col-sm-12 px-5 my-3 text-center">
         <span class="title"><a routerLink=""><img alt="DeX" src="assets/images/dex-logo-dark-orange.png"></a></span>
       </div>
-      <div class="col-lg-2 col-md-6 my-3">
+      <div class="col-lg-2 col-sm-6 my-3">
         <h4>Projects</h4>
         <div class="menu-items">
           <a routerLink="project/add/source" routerLinkActive="active">Add project</a>
           <a routerLink="project/overview" routerLinkActive="active">Projects Overview</a>
         </div>
       </div>
-      <div class="col-lg-2 col-md-6 my-3">
+      <div class="col-lg-2 col-sm-6 my-3">
         <h4>About</h4>
         <div class="menu-items">
           <a href="https://github.com/DigitalExcellence/dex-frontend/wiki" target="_blank"
@@ -38,14 +38,14 @@
           <a href="mailto:dex.fhict@gmail.com">Contact us</a>
         </div>
       </div>
-      <div class="col-lg-2 col-md-6 my-3">
+      <div class="col-lg-2 col-sm-6 my-3">
         <h4>More info</h4>
         <div class="menu-items">
           <a href="https://fontys.nl/" target="_blank" rel="noopener noreferrer">Fontys.nl</a>
           <a href="https://github.com/DigitalExcellence" target="_blank" rel="noopener noreferrer">Github Organization</a>
         </div>
       </div>
-      <div class="col-lg-2 col-md-6 my-3">
+      <div class="col-lg-2 col-sm-6 my-3">
         <h4>Legal</h4>
         <div class="menu-items">
           <a routerLink="privacy">Privacy policy</a>

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -20,17 +20,17 @@
 <footer>
   <div class="container">
     <div class="row">
-      <div class="col-1 offset-1">
+      <div class="col-lg-3 col-sm-12 px-5 my-3 text-center">
         <span class="title"><a routerLink=""><img alt="DeX" src="assets/images/dex-logo-dark-orange.png"></a></span>
       </div>
-      <div class="col-md-2 offset-1">
+      <div class="col-lg-2 col-md-6 my-3">
         <h4>Projects</h4>
         <div class="menu-items">
           <a routerLink="project/add/source" routerLinkActive="active">Add project</a>
           <a routerLink="project/overview" routerLinkActive="active">Projects Overview</a>
         </div>
       </div>
-      <div class="col-md-2">
+      <div class="col-lg-2 col-md-6 my-3">
         <h4>About</h4>
         <div class="menu-items">
           <a href="https://github.com/DigitalExcellence/dex-frontend/wiki" target="_blank"
@@ -38,15 +38,14 @@
           <a href="mailto:dex.fhict@gmail.com">Contact us</a>
         </div>
       </div>
-      <div class="col-md-2">
+      <div class="col-lg-2 col-md-6 my-3">
         <h4>More info</h4>
         <div class="menu-items">
           <a href="https://fontys.nl/" target="_blank" rel="noopener noreferrer">Fontys.nl</a>
           <a href="https://github.com/DigitalExcellence" target="_blank" rel="noopener noreferrer">Github Organization</a>
-
         </div>
       </div>
-      <div class="col-md-2">
+      <div class="col-lg-2 col-md-6 my-3">
         <h4>Legal</h4>
         <div class="menu-items">
           <a routerLink="privacy">Privacy policy</a>
@@ -55,9 +54,8 @@
       </div>
     </div>
     <div class="row justify-content-center">
-      <div class="col-3 copyright">
+      <div class="col-3 copyright text-center">
         <p>Find <strong>DeX</strong> on <a class="github-link" href="https://github.com/DigitalExcellence" target="_blank" rel="noopener noreferrer"><strong>GitHub</strong></a></p>
-
       </div>
     </div>
   </div>

--- a/src/app/components/footer/footer.component.scss
+++ b/src/app/components/footer/footer.component.scss
@@ -32,6 +32,7 @@ footer {
   .title {
     img {
       width: 100%;
+      max-width: 100px;
     }
   }
 
@@ -50,11 +51,21 @@ footer {
     a:nth-child(1) {
       margin-top: 0;
     }
+
+    @media screen and (max-width: 991px) {
+        text-align: center;
+    }
+  }
+
+  h4{
+      @media screen and (max-width: 991px) {
+        text-align: center;
+      }
   }
 
   .copyright {
-    margin-top: 48px;
-    
+    margin-top: 32px;
+
     a.github-link {
       color: $accent-color-primary;
     }

--- a/src/app/components/footer/footer.component.scss
+++ b/src/app/components/footer/footer.component.scss
@@ -52,13 +52,13 @@ footer {
       margin-top: 0;
     }
 
-    @media screen and (max-width: 991px) {
+    @include media-breakpoint-down(md) {
         text-align: center;
     }
   }
 
   h4{
-      @media screen and (max-width: 991px) {
+      @include media-breakpoint-down(md) {
         text-align: center;
       }
   }


### PR DESCRIPTION
## Description

Make the footer responsive for different screen sizes. Done by adding bootstrap classes to create breakpoints for the footer layout. Also fixed the problem that the line "Find DeX on GitHub" was not always centered on larger screens. Lastly, added media queries to center the text within the footer when the screen is small (smaller than 991px).

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.
These steps will be used during release testing.

1. Make screen 991px wide. The content in the footer should be split into 2 columns (with a centered Dex logo heading). Also, the text should be center in each column.
2. Make screen 575px wide. The content in the footer should be below each other in one column. Also, the text should be center in each column.

3. The line 'Find DeX on GitHub' should always be centered

## Link to issue

Closes: #163