### PR TITLE
Fixed redirect to project page after editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed all file line endings from CRLF to LF and added the .gitattributes to enforce it - [#163](https://github.com/DigitalExcellence/dex-backend/issues/163)
 - Highlight now shows highlight description instead of project description. - [#273](https://github.com/DigitalExcellence/dex-frontend/issues/273)
-- Changed footer styling to be responsive on small screens - [#163] (https://github.com/DigitalExcellence/dex-frontend/issues/163) 
+- Changed footer styling to be responsive on small screens - [#163](https://github.com/DigitalExcellence/dex-frontend/issues/163)
 
 
 ### Deprecated
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed issue where the feedback button would block the footer content on smaller screens - [#289](https://github.com/DigitalExcellence/dex-frontend/issues/289)
+- Fixed redirect to the project detail page after editing a project - [#256](https://github.com/DigitalExcellence/dex-frontend/issues/256)
 
 ### Security
 

--- a/src/app/modules/project/edit/edit.component.ts
+++ b/src/app/modules/project/edit/edit.component.ts
@@ -145,7 +145,7 @@ export class EditComponent implements OnInit {
           timeout: this.alertService.defaultTimeout
         };
         this.alertService.pushAlert(alertConfig);
-        this.router.navigate([`/project/overview`]);
+        this.router.navigate([`project/details/${this.project.id}`]);
       });
   }
 


### PR DESCRIPTION
## Description

Fixed issue where the user would be redirected to the project overview after editing a project. Now it sends them to the page of the project itself instead.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.
These steps will be used during release testing.

1. Edit a project
2. Check if you have been redirected to the project's specific page

## Link to issue

Closes: #256 
