### PR TITLE
349-project-icons-shrink-with-long-titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed issue where the project icons would shrink if the description or title was too long - [#349](https://github.com/DigitalExcellence/dex-frontend/issues/349)
+
 ### Security
 
 ## Release v.0.8.0-beta - 06-11-2020

--- a/src/app/modules/project/overview/overview.component.scss
+++ b/src/app/modules/project/overview/overview.component.scss
@@ -137,7 +137,7 @@
        .icon-placeholder {
          height: 70px;
          width: 70px;
-         min-width: 55px;
+         min-width: 70px;
          margin: 10px 20px;
          display: flex;
          align-items: center;
@@ -148,7 +148,7 @@
 
        img {
          height: 100%;
-         max-width: 100%;
+         width: 100%;
          object-fit: cover;
          margin: auto;
        }


### PR DESCRIPTION
## Description

The project icons shrunk down when a description or title was long

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I updated the changelog with an end-user readable description
-   [ ] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.
These steps will be used during release testing.

1. Create a project with an unnecessary long title
2. Go to the project overview page
3. The project icon should still look normal

#349 

Closes: #349 
