### PR TITLE
Fixes #339 - Show placeholder image when image path errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed alert box blocking project edit/-delete buttons - [#352](https://github.com/DigitalExcellence/dex-frontend/issues/352)
+- Fixed images showing alt when image could not be loaded, it now shows placeholder image instead - [#339](https://github.com/DigitalExcellence/dex-frontend/issues/339)
 
 ### Security
 

--- a/src/app/modules/highlight/top-highlight-cards/top-highlight-cards.component.html
+++ b/src/app/modules/highlight/top-highlight-cards/top-highlight-cards.component.html
@@ -33,7 +33,7 @@
     <div *ngFor="let highlight of highlights" class="col-md-12 col-lg-4 mb-4">
       <div class="card" (click)="onClickHighlightedProject(highlight.projectId, highlight.project.name)">
         <div class="card-title">
-          <div class="icon"><img [src]="getIconUrl(highlight.projectId)" alt="" loading="lazy"></div>
+          <div class="icon"><img [src]="getIconUrl(highlight.projectId)" onerror="this.src='/assets/images/placeholder.svg';" alt="" loading="lazy"></div>
           <h3>{{highlight.project.name}}</h3>
         </div>
         <p class="large">{{highlight.description | striphtml}}</p>

--- a/src/app/modules/project/details/details.component.html
+++ b/src/app/modules/project/details/details.component.html
@@ -29,7 +29,7 @@
     <div class="row">
       <div class="col-3 project-metadata">
         <div class="project-icon" style="background-color: unset">
-          <img alt="Code project" [src]="getIconUrl()" loading="lazy">
+          <img alt="Code project" [src]="getIconUrl()" onerror="this.src='/assets/images/placeholder.svg';" loading="lazy">
         </div>
         <div *ngIf="project.uri" class="project-metadata__item">
           <h3>External Link</h3>

--- a/src/app/modules/project/embed/embed.component.html
+++ b/src/app/modules/project/embed/embed.component.html
@@ -20,7 +20,7 @@
  <div *ngIf="project">
   <div class="row">
     <div class="col-sm-3 order-last order-sm-first project-metadata">
-      <div class="project-icon"><img alt="Code project" [src]="getIconUrl()" loading="lazy"></div>
+      <div class="project-icon"><img alt="Code project" [src]="getIconUrl()" onerror="this.src='/assets/images/placeholder.svg';" loading="lazy"></div>
       <div *ngIf="project.uri" class="project-metadata__item">
         <h3>External Link</h3>
         <p>

--- a/src/app/modules/project/overview/overview.component.html
+++ b/src/app/modules/project/overview/overview.component.html
@@ -123,7 +123,7 @@
         <tr *ngFor="let project of projectsToDisplay">
           <td class="title" (click)="onClickProject(project.id, project.name)">
             <div class="icon-placeholder">
-              <img align="middle" alt="project-image" [src]="getIconUrl(project.id)" loading="lazy">
+              <img align="middle" alt="project-image" [src]="getIconUrl(project.id)" onerror="this.src='/assets/images/placeholder.svg';" loading="lazy">
             </div>
             <span>
               <h3>{{ project.name }}</h3>


### PR DESCRIPTION
## Description

When images could not be loaded for whatever reason, it would show the alternate text and mess up the styling. If the image errors out, I will now show a placeholder image instead of errored image with alt text.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

This is difficult to test, you could upload a project icon, then delete it from API and refresh frontend. It should show the placeholder image instead.

## Link to issue

Closes: #339 
