### PR TITLE
302-pagination-parameters-not-cleared-on-new-search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed issue where the project icons would shrink if the description or title was too long - [#349](https://github.com/DigitalExcellence/dex-frontend/issues/349)
 - Fixed alert box blocking project edit/-delete buttons - [#352](https://github.com/DigitalExcellence/dex-frontend/issues/352)
-- Fixed issue where the pagination parameter was not getting resetted on a new search - [#302](https://github.com/DigitalExcellence/dex-frontend/issues/302)
+- Fixed issue where the pagination parameter was not getting reset on a new search - [#302](https://github.com/DigitalExcellence/dex-frontend/issues/302)
 - Fixed images showing alt when image could not be loaded, it now shows placeholder image instead - [#339](https://github.com/DigitalExcellence/dex-frontend/issues/339)
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed issue where the project icons would shrink if the description or title was too long - [#349](https://github.com/DigitalExcellence/dex-frontend/issues/349)
 - Fixed alert box blocking project edit/-delete buttons - [#352](https://github.com/DigitalExcellence/dex-frontend/issues/352)
+- Fixed issue where the pagination parameter was not getting resetted on a new search - [#302](https://github.com/DigitalExcellence/dex-frontend/issues/302)
 
 ### Security
 

--- a/src/app/modules/project/overview/overview.component.html
+++ b/src/app/modules/project/overview/overview.component.html
@@ -143,8 +143,12 @@
     </ng-container>
     <ng-template #noProjects>There are no projects available.</ng-template>
     <div *ngIf="amountOfProjectsOnSinglePage < totalNrOfProjects && showPaginationFooter" class="pagination-div">
-      <pagination [(totalItems)]="totalNrOfProjects" [(itemsPerPage)]="amountOfProjectsOnSinglePage"
-        [customNextTemplate]="nextTemplate" [customPreviousTemplate]="prevTemplate" (pageChanged)="pageChanged($event)" class="pagination-footer">
+      <pagination [(totalItems)]="totalNrOfProjects"
+                  [(itemsPerPage)]="amountOfProjectsOnSinglePage"
+                  [customNextTemplate]="nextTemplate"
+                  [customPreviousTemplate]="prevTemplate"
+                  [ngModel]="currentPage"
+                  (pageChanged)="pageChanged($event)" class="pagination-footer">
       </pagination>
       <ng-template #nextTemplate [customPreviousTemplate]="prevTemplate" let-disabled="disabled" let-currentPage="currentPage">
         <ng-container *ngIf="!disabled">

--- a/src/app/modules/project/overview/overview.component.ts
+++ b/src/app/modules/project/overview/overview.component.ts
@@ -243,7 +243,7 @@ export class OverviewComponent implements OnInit {
     // Reset the current page so we are sure we retrieve all the projects in the database and not
     // Just the ones on the current page. If the query is empty we should search for the projects
     // On the first page only
-    this.currentPage = value.trim() === '' ? 1 : null
+    this.currentPage = value.trim() === '' ? 1 : null;
     this.searchSubject.next(value);
   }
 

--- a/src/app/modules/project/overview/overview.component.ts
+++ b/src/app/modules/project/overview/overview.component.ts
@@ -239,6 +239,7 @@ export class OverviewComponent implements OnInit {
     }
 
     this.currentSearchInput = value;
+    this.currentPage = null;
     this.searchSubject.next(value);
   }
 

--- a/src/app/modules/project/overview/overview.component.ts
+++ b/src/app/modules/project/overview/overview.component.ts
@@ -142,7 +142,7 @@ export class OverviewComponent implements OnInit {
 
   public currentOnlyHighlightedProjects: boolean = null;
 
-  private currentPage = 1;
+  public currentPage = 1;
 
   constructor(
     private router: Router,
@@ -240,10 +240,6 @@ export class OverviewComponent implements OnInit {
 
     this.currentSearchInput = value;
 
-    // Reset the current page so we are sure we retrieve all the projects in the database and not
-    // Just the ones on the current page. If the query is empty we should search for the projects
-    // On the first page only
-    this.currentPage = value.trim() === '' ? 1 : null;
     this.searchSubject.next(value);
   }
 
@@ -331,12 +327,15 @@ export class OverviewComponent implements OnInit {
   private onInternalQueryChange(): void {
     const internalSearchQuery: InternalSearchQuery = {
       query: this.currentSearchInput === '' ? null : this.currentSearchInput,
-      page: this.currentPage,
+      // If there is a search query, search on all pages
+      page: !this.currentSearchInput ? this.currentPage : null,
       amountOnPage: this.amountOfProjectsOnSinglePage,
       sortBy: this.currentSortType,
       sortDirection: this.currentSortDirection,
       highlighted: this.currentOnlyHighlightedProjects,
     };
+
+    console.log(internalSearchQuery);
 
     if (internalSearchQuery.query == null) {
       // No search query provided use projectService.

--- a/src/app/modules/project/overview/overview.component.ts
+++ b/src/app/modules/project/overview/overview.component.ts
@@ -335,8 +335,6 @@ export class OverviewComponent implements OnInit {
       highlighted: this.currentOnlyHighlightedProjects,
     };
 
-    console.log(internalSearchQuery);
-
     if (internalSearchQuery.query == null) {
       // No search query provided use projectService.
       this.paginationService

--- a/src/app/modules/project/overview/overview.component.ts
+++ b/src/app/modules/project/overview/overview.component.ts
@@ -239,6 +239,8 @@ export class OverviewComponent implements OnInit {
     }
 
     this.currentSearchInput = value;
+    // Reset the current page so we are sure we retrieve all the projects in the database and not
+    // Just the ones on the current page
     this.currentPage = null;
     this.searchSubject.next(value);
   }

--- a/src/app/modules/project/overview/overview.component.ts
+++ b/src/app/modules/project/overview/overview.component.ts
@@ -239,9 +239,11 @@ export class OverviewComponent implements OnInit {
     }
 
     this.currentSearchInput = value;
+
     // Reset the current page so we are sure we retrieve all the projects in the database and not
-    // Just the ones on the current page
-    this.currentPage = null;
+    // Just the ones on the current page. If the query is empty we should search for the projects
+    // On the first page only
+    this.currentPage = value.trim() === '' ? 1 : null
     this.searchSubject.next(value);
   }
 


### PR DESCRIPTION
## Description

Currently, when you search for a project on the second page, you can't find any projects that are placed on a different page. This fix will clear the page query when the search input is updated

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.
These steps will be used during release testing.

1. Search for a project on the first page
2. Make sure that it appears in the results
3. Clear the search query
4. Go to the second page
5. Execute the same search
6. The project from the first page should show up

## #302 

Closes: #302 
