### PR TITLE
bugfix/433 auto dismiss popup if you're not logged in by liking project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Auto dismiss the login warning when liking project if you're not logged in - [433](https://github.com/DigitalExcellence/dex-frontend/issues/433)
+
 ### Security
 
 ## Release v.1.0.1-beta - 31-01-2021

--- a/src/app/modules/project/overview/project/project.component.ts
+++ b/src/app/modules/project/overview/project/project.component.ts
@@ -89,6 +89,7 @@ export class ProjectComponent {
         type: AlertType.warning,
         mainMessage: 'You need to be logged in to like a project',
         dismissible: true,
+        autoDismiss: true,
         timeout: this.alertService.defaultTimeout
       };
       this.alertService.pushAlert(alertConfig);


### PR DESCRIPTION
## Description

When trying to like a project, you will get a warning if you're not logged in. This warning didn't automatically dismiss itself, unlike all the other pop-ups. This is fixed, and the pop-up will automatically dismiss itself.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

1. Navigate to the project overview page.
2. Like a project if you're not logged in.
3. The warning pop up will appear
4. Wait 5 seconds and validate that the pop up will automatically disappear

## Link to issue

Closes: #433 
