### PR TITLE
Hide the project modal when you use the browser navigation

### DIFF
--- a/src/app/modules/project/details/details.component.ts
+++ b/src/app/modules/project/details/details.component.ts
@@ -17,7 +17,7 @@
 import { PlatformLocation } from '@angular/common';
 import {Component, Input, OnInit, ViewEncapsulation} from '@angular/core';
 import {SafeUrl} from '@angular/platform-browser';
-import {ActivatedRoute, Router} from '@angular/router';
+import {Router} from '@angular/router';
 import {BsModalService, ModalOptions} from 'ngx-bootstrap/modal';
 import {EMPTY, Observable, Subject} from 'rxjs';
 import {finalize, switchMap} from 'rxjs/operators';
@@ -42,6 +42,7 @@ import {LikeService} from 'src/app/services/like.service';
 import {ProjectService} from 'src/app/services/project.service';
 import {SEOService} from 'src/app/services/seo.service';
 import {environment} from 'src/environments/environment';
+import { HostListener } from '@angular/core';
 
 /**
  * Overview of a single project
@@ -110,9 +111,6 @@ export class DetailsComponent implements OnInit {
     private likeService: LikeService
   ) {
     this.onLike = new Subject<boolean>();
-
-    // Platform location should not be used directly
-    location.onPopState(() => this.modalService.hide(1));
   }
 
   ngOnInit(): void {
@@ -157,6 +155,18 @@ export class DetailsComponent implements OnInit {
           }
         });
     }
+  }
+
+  /**
+   * The pop state event is fired when the active history entry
+   * changes while the user navigates the session history. Whenever
+   * the user navigates to another route, this function will hide
+   * the active modal.
+   * @param event
+   */
+  @HostListener('window:popstate', ['$event'])
+  onPopState(event) {
+    this.hideModalAndRemoveClass();
   }
 
   public onClickCallToActionButton(url: string) {
@@ -366,9 +376,17 @@ export class DetailsComponent implements OnInit {
    * @param url the url to redirect to
    */
   public closeModalAndRedirect(url: string) {
+    this.hideModalAndRemoveClass();
+    this.router.navigate([url]);
+  }
+
+  /**
+   * This method will hide the active modal and remove the
+   * according class.
+   */
+  private hideModalAndRemoveClass(): void {
     this.modalService.hide(1);
     document.getElementsByTagName('body')[0].classList.remove('modal-open');
-    this.router.navigate([url]);
   }
 
   /**

--- a/src/app/modules/project/details/details.component.ts
+++ b/src/app/modules/project/details/details.component.ts
@@ -14,6 +14,7 @@
  *   along with this program, in the LICENSE.md file in the root project directory.
  *   If not, see https://www.gnu.org/licenses/lgpl-3.0.txt
  */
+import { PlatformLocation } from '@angular/common';
 import {Component, Input, OnInit, ViewEncapsulation} from '@angular/core';
 import {SafeUrl} from '@angular/platform-browser';
 import {ActivatedRoute, Router} from '@angular/router';
@@ -96,7 +97,7 @@ export class DetailsComponent implements OnInit {
   public animationTriggered = false;
 
   constructor(
-    private activedRoute: ActivatedRoute,
+    private location: PlatformLocation,
     private projectService: ProjectService,
     private authService: AuthService,
     private highlightService: HighlightService,
@@ -109,6 +110,9 @@ export class DetailsComponent implements OnInit {
     private likeService: LikeService
   ) {
     this.onLike = new Subject<boolean>();
+
+    // Platform location should not be used directly
+    location.onPopState(() => this.modalService.hide(1));
   }
 
   ngOnInit(): void {

--- a/src/app/modules/project/details/details.component.ts
+++ b/src/app/modules/project/details/details.component.ts
@@ -14,7 +14,7 @@
  *   along with this program, in the LICENSE.md file in the root project directory.
  *   If not, see https://www.gnu.org/licenses/lgpl-3.0.txt
  */
-import { PlatformLocation } from '@angular/common';
+
 import {Component, Input, OnInit, ViewEncapsulation} from '@angular/core';
 import {SafeUrl} from '@angular/platform-browser';
 import {Router} from '@angular/router';
@@ -98,7 +98,6 @@ export class DetailsComponent implements OnInit {
   public animationTriggered = false;
 
   constructor(
-    private location: PlatformLocation,
     private projectService: ProjectService,
     private authService: AuthService,
     private highlightService: HighlightService,

--- a/src/app/modules/project/details/details.component.ts
+++ b/src/app/modules/project/details/details.component.ts
@@ -162,7 +162,7 @@ export class DetailsComponent implements OnInit {
    * changes while the user navigates the session history. Whenever
    * the user navigates to another route, this function will hide
    * the active modal.
-   * @param event
+   * @param event that will be received when history entry changes.
    */
   @HostListener('window:popstate', ['$event'])
   onPopState(event) {


### PR DESCRIPTION
## Description

Hide the project modal when you use the browser navigation.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

1. Open a project detail page (or highlight via the homepage)
2. Use the browser navigation to go a page back (you can also use mouse buttons to go back if you have access to these)
3. Validate that the active modal disappears

## Link to issue

Closes: #423 
