### PR TITLE
Auto dismiss alerts on project overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed issue where alerts would never get dismissed - [#441](https://github.com/DigitalExcellence/dex-frontend/issues/441)
+
 ### Security
 
 ## Release v.1.3.0-beta - 05-05-2021

--- a/src/app/interceptors/http.interceptor.ts
+++ b/src/app/interceptors/http.interceptor.ts
@@ -136,11 +136,12 @@ export class HttpErrorInterceptor implements HttpInterceptor {
      */
     private createErrorAlertConfig(preMessage: string, mainMessage: string): AlertConfig {
         const alertConfig: AlertConfig = {
-            type: AlertType.danger,
-            preMessage: preMessage,
-            mainMessage: mainMessage,
-            dismissible: true,
-            timeout: this.alertService.defaultTimeout
+          type: AlertType.danger,
+          preMessage: preMessage,
+          mainMessage: mainMessage,
+          dismissible: true,
+          autoDismiss: true,
+          timeout: this.alertService.defaultTimeout
         };
         return alertConfig;
     }


### PR DESCRIPTION
## Description

Fix the http interceptor alerts. The timout time was set but the `autoDismiss` wasn't set so all the alerts that were created in the interceptor did not get dismissed.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I updated the changelog with an end-user readable description
-   [ ] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.
These steps will be used during release testing.

This issue probably won't happen anymore because the delete button functionality is working now so it's annoying to reproduce. The issue didn't just apply to the project overview page though, if you get any error that was handled by the interceptor it would not dismiss.
1. Hardcode the `displayEditButton` value to `true`
2. Go to a project that is not yours and try to delete it
3. The alert should go away

## Link to issue

Closes: #441 
