### PR TITLE
removed budget.json reference

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -15,6 +15,5 @@ jobs:
             https://staging.dex.software/project/overview
             https://staging.dex.software/project/add/source
             https://staging.dex.software/account/login
-          budgetPath: ./budget.json # test performance budgets
           uploadArtifacts: true # save results as an action artifacts
           temporaryPublicStorage: true # upload lighthouse report to the temporary storage


### PR DESCRIPTION
The budget.json is the reason why this CI/CD script keeps on failing. Another alternative way of solving this is by configuring the network throttling but I do not have time for this fix.

## Description
The lighthouse CI/CD check has been constantly failing for the previous months. The reason for this is the artificial throttling, caused by Lighthouse CI/CD. There are configuration files surrounding the network and cpu throttling of Lighthouse CI, but I could not get this to work in my own separate fork of the project. This is why I decided to remove the link to the `budget.json` file for now, solving the failed lighthouse check as well. 

## Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I updated the changelog with an end-user readable description
-   [ ] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce



