### PR TITLE
Feature/499 sort projects on likes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added project images. - [#464](https://github.com/DigitalExcellence/dex-frontend/issues/464)
 - Added images to highlights - [#463](https://github.com/DigitalExcellence/dex-frontend/issues/463)
-- Updated selection color to improve branding - [#539](https://github.com/DigitalExcellence/dex-frontend/issues/539) 
+- Updated selection color to improve branding - [#539](https://github.com/DigitalExcellence/dex-frontend/issues/539)
 - Added bot to optimize image sizes - [#440](https://github.com/DigitalExcellence/dex-frontend/issues/540)
+- Added search functionality based on the number of likes - [#499](https://github.com/DigitalExcellence/dex-frontend/issues/499)
 
 ### Changed
 

--- a/src/app/modules/project/overview/overview.component.ts
+++ b/src/app/modules/project/overview/overview.component.ts
@@ -111,6 +111,8 @@ export class OverviewComponent implements OnInit, AfterViewInit {
     {value: 'name,desc', viewValue: 'Name (z-a)'},
     {value: 'created,desc', viewValue: 'Created (new-old)'},
     {value: 'created,asc', viewValue: 'Created (old-new)'},
+    {value: 'likes,desc', viewValue: 'Likes (high-low)'},
+    {value: 'likes,asc', viewValue: 'Likes (low-high)'},
   ];
 
   public displaySearchElements = false;


### PR DESCRIPTION
## Description

Added search functionality based on the number of likes in the project overview page.

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

1. Navigate to the project overview page
2. Like some projects
3. Select in the filter menu 'Likes (high-low)
4. Validate that the projects get sorted on the number of likes in desc order
5. Select in the filter menu 'LIkes (low-high)
6. Validate that the projects get sorted on the number of likes in asc order

## Link to issue

Closes: #499 
