### PR TITLE
Bug/512 homepage like in background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 
 ### Fixed
+- Recommended project cards now update likes given on an open modal - [#512](https://github.com/DigitalExcellence/dex-frontend/issues/512)
 
 ### Security
 

--- a/src/app/modules/home/recommendations/recommendations.component.ts
+++ b/src/app/modules/home/recommendations/recommendations.component.ts
@@ -72,6 +72,7 @@ export class RecommendationCardsComponent implements OnInit {
   public onClickRecommendedProject(id: number, name: string): void {
     name = name.split(' ').join('-');
     this.modalUtility.openProjectModal(id, name, '/home');
+    this.modalUtility.subscribeToLikes(id, this.recommendations);
   }
 
   /**

--- a/src/app/modules/project/overview/overview.component.ts
+++ b/src/app/modules/project/overview/overview.component.ts
@@ -63,16 +63,16 @@ export class OverviewComponent implements OnInit, AfterViewInit {
   public amountOfProjectsOnSinglePage = 12;
 
   constructor(
-      private router: Router,
-      private paginationService: PaginationService,
-      private internalSearchService: InternalSearchService,
-      private formBuilder: FormBuilder,
-      private activatedRoute: ActivatedRoute,
-      private seoService: SEOService,
-      private location: Location,
-      private categoryService: CategoryService,
-      private route: ActivatedRoute,
-      private modalUtility: ProjectDetailModalUtility) {
+    private router: Router,
+    private paginationService: PaginationService,
+    private internalSearchService: InternalSearchService,
+    private formBuilder: FormBuilder,
+    private activatedRoute: ActivatedRoute,
+    private seoService: SEOService,
+    private location: Location,
+    private categoryService: CategoryService,
+    private route: ActivatedRoute,
+    private modalUtility: ProjectDetailModalUtility) {
   }
 
   ngOnInit(): void {
@@ -81,13 +81,30 @@ export class OverviewComponent implements OnInit, AfterViewInit {
 
   ngAfterViewInit(): void {
     this.route.params.subscribe(params => {
-      const projectId = params.id?.split('-')[0];
+      const projectId = +params.id?.split('-')[0];
 
       // We need the 1ms timeout to make sure the components are rendered, I don't know why angular doesn't do this but whatever
       setTimeout(() => {
         this.amountOfProjectsOnSinglePage = this.filterMenu.amountOfProjectsOnSinglePage;
+
+        // Methods below are executed when an ID has been provided in the URL
         if (projectId) {
-          this.modalUtility.openProjectModal(projectId, '' , '/project/overview');
+          this.modalUtility.openProjectModal(projectId, '', '/project/overview');
+
+          // Interval to wait for projects to be loaded (Not a pretty solution, but coudn't find a better way)
+          const checkLoading = setInterval(() => {
+            if (!this.projectsLoading) {
+              // When projects are loaded, check if project is on overviewpage (in background) and subscribe to updated likes if needed
+              this.filteredProjects.forEach(project => {
+                if (project.id === projectId) {
+                  this.modalUtility.subscribeToLikes(projectId, this.filteredProjects);
+                }
+              });
+              // stop interval as soon as projects are loaded:
+              clearInterval(checkLoading);
+            }
+          }, 10);
+
         }
       }, 1);
     });

--- a/src/app/modules/project/overview/overview.component.ts
+++ b/src/app/modules/project/overview/overview.component.ts
@@ -84,7 +84,6 @@ export class OverviewComponent implements OnInit, AfterViewInit {
       // We need the 1ms timeout to make sure the components are rendered, I don't know why angular doesn't do this but whatever
       setTimeout(() => {
         this.amountOfProjectsOnSinglePage = this.filterMenu.amountOfProjectsOnSinglePage;
-        this.projectList.createProjectModal(projectId);
       }, 1);
     });
   }

--- a/src/app/modules/project/overview/overview.component.ts
+++ b/src/app/modules/project/overview/overview.component.ts
@@ -26,6 +26,7 @@ import { CategoryService } from 'src/app/services/category.service';
 import { InternalSearchService } from 'src/app/services/internal-search.service';
 import { PaginationService } from 'src/app/services/pagination.service';
 import { SEOService } from 'src/app/services/seo.service';
+import { ProjectDetailModalUtility } from 'src/app/utils/project-detail-modal.util';
 import { environment } from 'src/environments/environment';
 
 /**
@@ -70,7 +71,8 @@ export class OverviewComponent implements OnInit, AfterViewInit {
       private seoService: SEOService,
       private location: Location,
       private categoryService: CategoryService,
-      private route: ActivatedRoute) {
+      private route: ActivatedRoute,
+      private modalUtility: ProjectDetailModalUtility) {
   }
 
   ngOnInit(): void {
@@ -84,6 +86,9 @@ export class OverviewComponent implements OnInit, AfterViewInit {
       // We need the 1ms timeout to make sure the components are rendered, I don't know why angular doesn't do this but whatever
       setTimeout(() => {
         this.amountOfProjectsOnSinglePage = this.filterMenu.amountOfProjectsOnSinglePage;
+        if (projectId) {
+          this.modalUtility.openProjectModal(projectId, '' , '/project/overview');
+        }
       }, 1);
     });
   }

--- a/src/app/utils/project-detail-modal.util.ts
+++ b/src/app/utils/project-detail-modal.util.ts
@@ -33,6 +33,25 @@ export class ProjectDetailModalUtility {
     this.location.replaceState(`/project/details/${id}-${name}`);
   }
 
+    /**
+   * Method to update like-count in background of modal
+   * @param id project id.
+   * @param element the object that needs to be updated in background
+   */
+  public subscribeToLikes(id: number, element) {
+    console.log(element);
+    this.modalRef.content.onLike.subscribe(isLiked => {
+      const projectIndexToUpdate = element.findIndex(project => project.id === id);
+      if (isLiked) {
+        element[projectIndexToUpdate].likeCount++;
+        element[projectIndexToUpdate].userHasLikedProject = true;
+      } else {
+        element[projectIndexToUpdate].likeCount--;
+        element[projectIndexToUpdate].userHasLikedProject = false;
+      }
+    });
+  }
+
   /**
    * Method to open the modal for a projects detail
    * @param projectId the id of the project that should be shown.

--- a/src/app/utils/project-detail-modal.util.ts
+++ b/src/app/utils/project-detail-modal.util.ts
@@ -34,7 +34,8 @@ export class ProjectDetailModalUtility {
     } else {
       this.createProjectModal(id, returnPage, 'description');
     }
-    this.location.replaceState(`/project/details/${id}-${name}`);
+    const newUrl = name ? `/project/details/${id}-${name}` : `/project/details/${id}`;
+    this.location.replaceState(newUrl);
   }
 
     /**

--- a/src/app/utils/project-detail-modal.util.ts
+++ b/src/app/utils/project-detail-modal.util.ts
@@ -26,10 +26,14 @@ export class ProjectDetailModalUtility {
    * @param id project id.
    * @param name project name
    */
-  public openProjectModal(id: number, name: string, returnPage: string): void {
+  public openProjectModal(id: number, name: string, returnPage: string, activeTab?: string): void {
     name = name.split(' ').join('-');
 
-    this.createProjectModal(id, returnPage);
+    if (activeTab) {
+      this.createProjectModal(id, returnPage, activeTab);
+    } else {
+      this.createProjectModal(id, returnPage, 'description');
+    }
     this.location.replaceState(`/project/details/${id}-${name}`);
   }
 
@@ -56,7 +60,7 @@ export class ProjectDetailModalUtility {
    * @param projectId the id of the project that should be shown.
    * @param activeTab Define the active tab
    */
-  private createProjectModal(projectId: number, returnPage: string, activeTab: string = 'description') {
+  private createProjectModal(projectId: number, returnPage: string, activeTab: string) {
     const initialState = {
       projectId: projectId,
       activeTab: activeTab,

--- a/src/app/utils/project-detail-modal.util.ts
+++ b/src/app/utils/project-detail-modal.util.ts
@@ -39,7 +39,6 @@ export class ProjectDetailModalUtility {
    * @param element the object that needs to be updated in background
    */
   public subscribeToLikes(id: number, element) {
-    console.log(element);
     this.modalRef.content.onLike.subscribe(isLiked => {
       const projectIndexToUpdate = element.findIndex(project => project.id === id);
       if (isLiked) {


### PR DESCRIPTION
## Description

Recommended project cards now update likes given on an open modal

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

1. Go to your homepage, make sure you have recommended projects
(like some projects if you dont have recommended projects)
2. Open your first recommended project
3. Click like in the modal
4. Check that the likes on the card in the background are updated too

## Link to issue

Closes: #512 
