### PR TITLE
Bug/555 scale filter menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Added scroll to the filtermenu to make sure it doesn't hide on screens with small height - [#555](https://github.com/DigitalExcellence/dex-frontend/issues/555)
+- Fixed problem where project overview card changes size on open modal - [#571](https://github.com/DigitalExcellence/dex-frontend/issues/571)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 
 ### Fixed
+- Added scroll to the filtermenu to make sure it doesn't hide on screens with small height - [#555](https://github.com/DigitalExcellence/dex-frontend/issues/555)
 
 ### Security
 

--- a/src/app/modules/project/details/details.component.scss
+++ b/src/app/modules/project/details/details.component.scss
@@ -31,14 +31,15 @@
     border: none;
   }
 }
-
-.project-info {
-  padding: 45px 60px;
-  display: flex;
-  gap: 30px;
-  flex-direction: column;
-  width: 800px;
-  max-width: 100%;
+.project-modal-content {
+  .project-info {
+    padding: 45px 60px;
+    display: flex;
+    gap: 30px;
+    flex-direction: column;
+    width: 800px;
+    max-width: 100%;
+  }
 }
 
 .highlight-modal {
@@ -70,7 +71,7 @@
     border: none;
     width: fit-content;
     margin: 0 auto;
-    max-width: 100%
+    max-width: 100%;
   }
 }
 

--- a/src/app/modules/project/overview/filter-menu/filter-menu.component.scss
+++ b/src/app/modules/project/overview/filter-menu/filter-menu.component.scss
@@ -12,6 +12,11 @@
   padding: 48px 36px 12px 36px;
   background-color: white;
   overflow-y: auto;
+  direction: rtl; //put scrollbar on the left 
+
+  .projects-filter{
+    direction: ltr; //resets direction change needed for scrollbar on left
+  }
 
   .divider {
     border-bottom: 1px solid $light-mode-grey-thertiary;

--- a/src/app/modules/project/overview/filter-menu/filter-menu.component.scss
+++ b/src/app/modules/project/overview/filter-menu/filter-menu.component.scss
@@ -9,15 +9,16 @@
   position: sticky;
   top: 0;
   margin: -24px 24px -64px -24px; // override padding from parent element & footer
-  padding: 48px 36px;
+  padding: 48px 36px 12px 36px;
   background-color: white;
+  overflow-y: auto;
 
   .divider {
     border-bottom: 1px solid $light-mode-grey-thertiary;
   }
 
   .filter-group {
-    padding: 24px 0;
+    padding: 12px 0;
     display: flex;
     flex-direction: column;
     color: $light-mode-grey-primary;

--- a/src/app/modules/project/overview/filter-menu/filter-menu.component.scss
+++ b/src/app/modules/project/overview/filter-menu/filter-menu.component.scss
@@ -14,7 +14,7 @@
   overflow-y: auto;
   direction: rtl; //put scrollbar on the left 
 
-  .projects-filter{
+  .projects-filter {
     direction: ltr; //resets direction change needed for scrollbar on left
   }
 


### PR DESCRIPTION
## Description

Small fix of an issue where the filter-menu became partially hidden on screens with a small height. 

Added fix for changing cards on open modal

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

1. Go to the project overview page
2. Make your window-height smaller. Either by dragging it or trough inspecting the element as described in the linked issue
3. See the scrollbar appear on the filtermenu and check that you can use all the filters 

## Link to issue

Closes: #555 
Closes: #571
