### PR TITLE
Fixed project overview not automatically sorting on likes high-low

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 ### Changed
+- Projects overview not sorting on Likes High > Low [#557](https://github.com/DigitalExcellence/dex-frontend/issues/557)
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
-- Projects overview not sorting on Likes High > Low [#557](https://github.com/DigitalExcellence/dex-frontend/issues/557)
+
 ### Security
 
 ##  Release v.1.6.0-beta - 15-9-2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+##  Release v.1.7.0 - 29-9-2021
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+- Projects overview not sorting on Likes High > Low [#557](https://github.com/DigitalExcellence/dex-frontend/issues/557)
+### Security
+
 ##  Release v.1.6.0-beta - 15-9-2021
 
 ### Added

--- a/src/app/modules/project/overview/filter-menu/filter-menu.component.ts
+++ b/src/app/modules/project/overview/filter-menu/filter-menu.component.ts
@@ -45,14 +45,14 @@ export class FilterMenuComponent implements OnInit {
   ];
 
   public sortSelectOptions: SelectFormOption[] = [
+    {value: 'likes,desc', viewValue: 'Likes (high-low)'},
+    {value: 'likes,asc', viewValue: 'Likes (low-high)'},
     {value: 'updated,desc', viewValue: 'Updated (new-old)'},
     {value: 'updated,asc', viewValue: 'Updated (old-new)'},
     {value: 'name,asc', viewValue: 'Name (a-z)'},
     {value: 'name,desc', viewValue: 'Name (z-a)'},
     {value: 'created,desc', viewValue: 'Created (new-old)'},
-    {value: 'created,asc', viewValue: 'Created (old-new)'},
-    {value: 'likes,desc', viewValue: 'Likes (high-low)'},
-    {value: 'likes,asc', viewValue: 'Likes (low-high)'},
+    {value: 'created,asc', viewValue: 'Created (old-new)'}
   ];
 
   /**


### PR DESCRIPTION
## Description
The default sorting is now on Liked high-low projects. Before it was on Created new-old.

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

Steps to reproduce the behavior:
1: Go to the project overview
2: Look at the way the projects are sorted

## Link to issue

Closes: #557 
