### PR TITLE
Fixed modal disappearing highlight form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 
 ### Fixed
+- Highlight project modal, not dissapearing when clicking out of it.[#569](https://github.com/DigitalExcellence/dex-frontend/issues/569)
 
 ### Security
 

--- a/src/app/modules/project/modal-highlight-form/modal-highlight-form.component.ts
+++ b/src/app/modules/project/modal-highlight-form/modal-highlight-form.component.ts
@@ -170,7 +170,6 @@ export class ModalHighlightFormComponent implements OnInit, AfterViewInit {
    * Method which triggers when the back button is clicked.
    */
   public onClickBack(): void {
-    this.goBack.emit();
     this.bsModalRef.hide();
   }
 


### PR DESCRIPTION
## Description

Fixed highlight project modal, not disappearing when clicking out of it. 

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce

1. Log in as an admin
2. Open up a project, click the cogwheel.
3. On popup click higlight settings.
4. Try to click outside the modal. It does not work.

## Link to issue

Closes: #569 
