### PR TITLE
Feature/526 pagination to own projects page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+##  Release v.1.7.0-beta - 8-10-2021
+
+### Added
+- Added pagination to own projects page. [#526](https://github.com/DigitalExcellence/dex-frontend/issues/526)
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
 ##  Release v.1.6.0-beta - 15-9-2021
 
 ### Added

--- a/src/app/modules/project/project.module.ts
+++ b/src/app/modules/project/project.module.ts
@@ -96,7 +96,8 @@ import { SafeHtmlPipe } from 'src/app/utils/safeHtml.pipe';
     FileUploaderComponent,
     SafeHtmlPipe,
     ProjectComponent,
-    CallToActionsEditComponent
+    CallToActionsEditComponent,
+    PaginationComponent
   ],
   providers: [Meta]
 })

--- a/src/app/modules/user/user-projects/user-projects.component.html
+++ b/src/app/modules/user/user-projects/user-projects.component.html
@@ -49,7 +49,7 @@
        <h3> {{ userName }} </h3>
        <div class="user-amounts">
        <div class="grid-item"><p>Projects:</p></div>
-       <div class="grid-item"><p>{{ userprojects.length }}</p></div>
+       <div class="grid-item"><p>{{ totalAmountOfProjects }}</p></div>
 
        </div>
       </div>
@@ -59,11 +59,37 @@
       <div class="project-list-wrapper" [ngClass]="this.showListView ? 'list' : 'grid'">
         <app-project
             (click)="onClickProject($event, project.id, project.name)"
-            *ngFor="let project of userprojects"
+            *ngFor="let project of userProjects"
             [project]="project"
             [showListView]="this.showListView"
         >
         </app-project>
+      </div>
+      <div class="pagination-div">
+        <pagination
+            [totalItems]="totalAmountOfProjects"
+            [itemsPerPage]="pageSize"
+            [customNextTemplate]="nextTemplate"
+            [customPreviousTemplate]="prevTemplate"
+            (pageChanged)="pageChanged($event)"
+            class="pagination-footer"
+        ></pagination>
+        <ng-template #nextTemplate let-currentPage="currentPage" let-disabled="disabled">
+          <ng-container *ngIf="!disabled">
+            <span class="chevron-right fas fa-chevron-down"></span>
+          </ng-container>
+          <ng-container *ngIf="disabled">
+            <span class="chevron-right disabled fas fa-chevron-down"></span>
+          </ng-container>
+        </ng-template>
+        <ng-template #prevTemplate let-currentPage="currentPage" let-disabled="disabled">
+          <ng-container *ngIf="!disabled">
+            <span class="chevron-left fas fa-chevron-down"></span>
+          </ng-container>
+          <ng-container *ngIf="disabled">
+            <span class="chevron-left fas fa-chevron-down disabled"></span>
+          </ng-container>
+        </ng-template>
       </div>
     </ng-container>
 

--- a/src/app/modules/user/user-projects/user-projects.component.html
+++ b/src/app/modules/user/user-projects/user-projects.component.html
@@ -86,7 +86,7 @@
         >
         </app-project>
       </div>
-      <div class="pagination-div">
+      <div *ngIf="!projectsEmpty()" class="pagination-div">
         <pagination
             [totalItems]="totalAmountOfProjects"
             [itemsPerPage]="amountOnPage"

--- a/src/app/modules/user/user-projects/user-projects.component.html
+++ b/src/app/modules/user/user-projects/user-projects.component.html
@@ -79,8 +79,8 @@
     <ng-container *ngIf="projectsLoading; else projectsLoading">
       <div class="project-list-wrapper" [ngClass]="this.showListView ? 'list' : 'grid'">
         <app-project
-            (click)="onClickProject($event, project.id, project.name)"
             *ngFor="let project of userProjects"
+            (click)="onClickUserProject(project.id, project.name)"
             [project]="project"
             [showListView]="this.showListView"
         >

--- a/src/app/modules/user/user-projects/user-projects.component.html
+++ b/src/app/modules/user/user-projects/user-projects.component.html
@@ -86,31 +86,14 @@
         >
         </app-project>
       </div>
-      <div *ngIf="!projectsEmpty()" class="pagination-div">
-        <pagination
-            [totalItems]="totalAmountOfProjects"
-            [itemsPerPage]="amountOnPage"
-            [customNextTemplate]="nextTemplate"
-            [customPreviousTemplate]="prevTemplate"
-            (pageChanged)="pageChanged($event)"
-            class="pagination-footer"
-        ></pagination>
-        <ng-template #nextTemplate let-currentPage="currentPage" let-disabled="disabled">
-          <ng-container *ngIf="!disabled">
-            <span class="chevron-right fas fa-chevron-down"></span>
-          </ng-container>
-          <ng-container *ngIf="disabled">
-            <span class="chevron-right disabled fas fa-chevron-down"></span>
-          </ng-container>
-        </ng-template>
-        <ng-template #prevTemplate let-currentPage="currentPage" let-disabled="disabled">
-          <ng-container *ngIf="!disabled">
-            <span class="chevron-left fas fa-chevron-down"></span>
-          </ng-container>
-          <ng-container *ngIf="disabled">
-            <span class="chevron-left fas fa-chevron-down disabled"></span>
-          </ng-container>
-        </ng-template>
+        <div *ngIf="!projectsEmpty()" class="pagination-div">
+          <app-pagination
+              (pageChanged)="pageChanged($event)"
+              [amountOfProjectsOnSinglePage]="amountOnPage"
+              [totalNumberOfProjects]="totalAmountOfProjects"
+              [showPaginationFooter]="showPaginationFooter && !projectsEmpty()"
+          >
+          </app-pagination>
       </div>
     </ng-container>
     <ng-container *ngIf="projectsEmpty()">

--- a/src/app/modules/user/user-projects/user-projects.component.html
+++ b/src/app/modules/user/user-projects/user-projects.component.html
@@ -15,14 +15,38 @@
    along with this program, in the LICENSE.md file in the root project directory.
    If not, see https://www.gnu.org/licenses/lgpl-3.0.txt
 -->
-
 <div class="row">
-
-
+  <div class="col-md-2 projects-filter-wrapper">
+    <div class="projects-filter">
+      <h3><em class="fas fa-filter"></em> Filters</h3>
+      <div class="divider"></div>
+      <div class="filter-group">
+        <h4>Sort Options</h4>
+        <form class="sort-options-form">
+          <label for="asc-desc">Sort options</label>
+          <select (change)="onSortChange()" [formControl]="sortOptionControl" class="option-select" id="asc-desc">
+            <option *ngFor="let sortOption of sortSelectOptions" [ngValue]="sortOption">
+              {{ sortOption.viewValue }}
+            </option>
+          </select>
+        </form>
+      </div>
+      <div class="divider"></div>
+      <div class="filter-group">
+        <h4>Pagination</h4>
+        <label>Projects per page</label>
+        <select (change)="onPaginationChange()" [formControl]="paginationOptionControl" class="option-select">
+          <option *ngFor="let paginationOption of paginationDropDownOptions" [ngValue]="paginationOption" class="paginationDropDown">
+            {{ paginationOption.amountOnPage }}
+          </option>
+        </select>
+      </div>
+      <div class="divider"></div>
+    </div>
+  </div>
   <div class="col-md projects-overview-wrapper">
     <div class="project-list-header">
       <h1 class="">My projects</h1>
-
       <div class="list-view-toggle">
         <label class="container">
           <input [(ngModel)]="showListView" [value]="false" aria-label="Switch to grid view" name="list-view" type="radio"/>
@@ -42,7 +66,6 @@
         </label>
       </div>
     </div>
-
     <div class="userinfo">
       <img alt="" class="profile-picture" loading="lazy" src="assets/images/profile-placeholder.png" />
       <div class="usercreds">
@@ -50,11 +73,9 @@
        <div class="user-amounts">
        <div class="grid-item"><p>Projects:</p></div>
        <div class="grid-item"><p>{{ totalAmountOfProjects }}</p></div>
-
        </div>
       </div>
     </div>
-
     <ng-container *ngIf="projectsLoading; else projectsLoading">
       <div class="project-list-wrapper" [ngClass]="this.showListView ? 'list' : 'grid'">
         <app-project
@@ -68,7 +89,7 @@
       <div class="pagination-div">
         <pagination
             [totalItems]="totalAmountOfProjects"
-            [itemsPerPage]="pageSize"
+            [itemsPerPage]="amountOnPage"
             [customNextTemplate]="nextTemplate"
             [customPreviousTemplate]="prevTemplate"
             (pageChanged)="pageChanged($event)"
@@ -92,12 +113,10 @@
         </ng-template>
       </div>
     </ng-container>
-
     <ng-container *ngIf="projectsEmpty()">
       <h3>No projects found</h3>
       <button class="primary" (click)="addProjectClicked()">Create project</button>
     </ng-container>
-
     <ng-template #projectsLoading>
       <h2 class="fas fa-spinner fa-pulse loading-circle" *ngIf="userProjectsLoading"></h2>
       <p *ngIf="!userProjectsLoading">There are no projects available.</p>

--- a/src/app/modules/user/user-projects/user-projects.component.scss
+++ b/src/app/modules/user/user-projects/user-projects.component.scss
@@ -133,4 +133,3 @@
   }
 
  @import "app/modules/project/overview/filter-menu/filter-menu.component.scss";
- @import "app/modules/project/overview/pagination/pagination.component.scss";

--- a/src/app/modules/user/user-projects/user-projects.component.scss
+++ b/src/app/modules/user/user-projects/user-projects.component.scss
@@ -207,3 +207,67 @@
      border-bottom: 1px solid $light-mode-grey-thertiary;
    }
   }
+
+.pagination-div {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+}
+
+.pagination-footer::ng-deep {
+  flex-wrap: wrap;
+
+  .pagination-next,
+  .pagination-prev {
+    max-width: 35px;
+    overflow: hidden;
+  }
+}
+
+.pagination-footer::ng-deep .page-link {
+  z-index: 1;
+  color: $light-mode-black;
+  height: 35px;
+  display: flex;
+  align-items: center;
+}
+
+.pagination-footer::ng-deep .page-item.active .page-link {
+  border-color: $accent-color-red-primary;
+  background-color: $accent-color-red-primary !important;
+  color: #ffffff;
+}
+
+.pagination-footer {
+  li {
+    height: 35px;
+    width: 35px;
+  }
+
+  a {
+    height: 35px;
+    width: 35px;
+  }
+
+  img {
+    width: 100%;
+  }
+
+  .chevron-right {
+    margin-top: 1px;
+    transform: rotateZ(270deg);
+  }
+
+  .chevron-left {
+    margin-top: 1px;
+    transform: rotateZ(90deg);
+  }
+
+  .disabled {
+    opacity: 0.3;
+  }
+}
+
+.paginationDropDown {
+  width: 80px;
+}

--- a/src/app/modules/user/user-projects/user-projects.component.scss
+++ b/src/app/modules/user/user-projects/user-projects.component.scss
@@ -17,6 +17,8 @@
  *
  */
  @import "assets/styles/variables";
+ @import "app/modules/project/overview/project-list/project-list.component.scss";
+
 
  .userinfo{
     display: flex;
@@ -100,84 +102,6 @@
    margin-left: auto;
    margin-right: auto;
 
-   .project-list-header {
-     width: 100%;
-     margin: 2em 0;
-     display: inline-flex;
-     justify-content: space-between;
-     align-content: center;
-
-     h1 {
-       display: inline;
-     }
-     .list-view-toggle {
-       display: flex;
-       margin: auto 0 auto 20px;
-       gap: 12px;
-       flex-wrap: wrap;
-       justify-content: flex-end;
-
-       @media only screen and (max-width: 720px) {
-         display: none;
-       }
-
-       .container {
-         box-shadow: $box-shadow;
-         display: inline;
-         position: relative;
-         cursor: pointer;
-         -webkit-user-select: none;
-         -moz-user-select: none;
-         -ms-user-select: none;
-         user-select: none;
-         padding: 0;
-         width: fit-content;
-         margin: 0;
-         height: fit-content;
-       }
-
-       // Hide the default radio button
-       .container input[type="radio"] {
-         position: absolute;
-         opacity: 0;
-         cursor: pointer;
-         height: 0;
-         width: 0;
-       }
-
-       // Create custom radio button
-       .checkmark {
-         height: 40px;
-         width: 40px;
-         padding: 10px;
-         border-radius: 5px;
-         background-color: $white;
-         color: $accent-color-red-primary;
-         display: flex;
-         justify-content: center;
-         align-items: center;
-         transition: transform $transition-short;
-
-         &:hover {
-           transform: $transform-grow-big;
-         }
-         svg {
-           size: inherit;
-           width: 100%;
-           height: 100%;
-           margin: 0;
-         }
-       }
-     }
-
-     // If the sibling input is checked
-     .container input[type="radio"]:checked ~ .checkmark {
-       color: $light-mode-grey-quaternary;
-       background: $accent-color-red-primary;
-     }
-   }
-
-
    .project-list-wrapper {
      width: 100%;
      display: grid;
@@ -208,66 +132,5 @@
    }
   }
 
-.pagination-div {
-  margin-top: 20px;
-  display: flex;
-  justify-content: center;
-}
-
-.pagination-footer::ng-deep {
-  flex-wrap: wrap;
-
-  .pagination-next,
-  .pagination-prev {
-    max-width: 35px;
-    overflow: hidden;
-  }
-}
-
-.pagination-footer::ng-deep .page-link {
-  z-index: 1;
-  color: $light-mode-black;
-  height: 35px;
-  display: flex;
-  align-items: center;
-}
-
-.pagination-footer::ng-deep .page-item.active .page-link {
-  border-color: $accent-color-red-primary;
-  background-color: $accent-color-red-primary !important;
-  color: #ffffff;
-}
-
-.pagination-footer {
-  li {
-    height: 35px;
-    width: 35px;
-  }
-
-  a {
-    height: 35px;
-    width: 35px;
-  }
-
-  img {
-    width: 100%;
-  }
-
-  .chevron-right {
-    margin-top: 1px;
-    transform: rotateZ(270deg);
-  }
-
-  .chevron-left {
-    margin-top: 1px;
-    transform: rotateZ(90deg);
-  }
-
-  .disabled {
-    opacity: 0.3;
-  }
-}
-
-.paginationDropDown {
-  width: 80px;
-}
+ @import "app/modules/project/overview/filter-menu/filter-menu.component.scss";
+ @import "app/modules/project/overview/pagination/pagination.component.scss";

--- a/src/app/modules/user/user-projects/user-projects.component.ts
+++ b/src/app/modules/user/user-projects/user-projects.component.ts
@@ -20,7 +20,7 @@ import { InternalSearchQuery } from 'src/app/models/resources/internal-search-qu
 
 import { Location } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
-import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormControl } from '@angular/forms';
 import { SafeUrl } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
@@ -163,7 +163,7 @@ export class UserProjectsComponent implements OnInit {
    * Checks whether there are any projects
    */
   public projectsEmpty(): boolean {
-    return this.userProjects.length < 1;
+    return this.totalAmountOfProjects < 1;
   }
 
   /**
@@ -250,7 +250,6 @@ export class UserProjectsComponent implements OnInit {
   public pageChanged(event: number) {
     this.internalSearchQuery.page = event;
     this.getUserProjects(this.internalSearchQuery);
-    return;
   }
 
   /**

--- a/src/app/modules/user/user-projects/user-projects.component.ts
+++ b/src/app/modules/user/user-projects/user-projects.component.ts
@@ -15,9 +15,6 @@
  *   If not, see https://www.gnu.org/licenses/lgpl-3.0.txt
  */
 
-import { SelectFormOption } from 'src/app/interfaces/select-form-option';
-import { InternalSearchQuery } from 'src/app/models/resources/internal-search-query';
-
 import { Location } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
@@ -25,7 +22,9 @@ import { SafeUrl } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { finalize } from 'rxjs/operators';
+import { SelectFormOption } from 'src/app/interfaces/select-form-option';
 import { Project } from 'src/app/models/domain/project';
+import { InternalSearchQuery } from 'src/app/models/resources/internal-search-query';
 import { DetailsComponent } from 'src/app/modules/project/details/details.component';
 import { AuthService } from 'src/app/services/auth.service';
 import { FileRetrieverService } from 'src/app/services/file-retriever.service';

--- a/src/app/modules/user/user-projects/user-projects.component.ts
+++ b/src/app/modules/user/user-projects/user-projects.component.ts
@@ -15,9 +15,8 @@
  *   If not, see https://www.gnu.org/licenses/lgpl-3.0.txt
  */
 
-import { SelectFormOption } from '../../../interfaces/select-form-option';
-import { InternalSearchQuery } from '../../../models/resources/internal-search-query';
-import { InternalSearchService } from '../../../services/internal-search.service';
+import { SelectFormOption } from 'src/app/interfaces/select-form-option';
+import { InternalSearchQuery } from 'src/app/models/resources/internal-search-query';
 
 import { Location } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
@@ -25,7 +24,6 @@ import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { SafeUrl } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
-import { PageChangedEvent } from 'ngx-bootstrap/pagination';
 import { finalize } from 'rxjs/operators';
 import { Project } from 'src/app/models/domain/project';
 import { DetailsComponent } from 'src/app/modules/project/details/details.component';
@@ -56,7 +54,6 @@ export class UserProjectsComponent implements OnInit {
     sortDirection: '',
     categories: null
   };
-
 
   /**
    * User info
@@ -250,8 +247,8 @@ export class UserProjectsComponent implements OnInit {
     this.router.navigateByUrl('project/add');
   }
 
-  public pageChanged(event: PageChangedEvent) {
-    this.internalSearchQuery.page = event.page;
+  public pageChanged(event: number) {
+    this.internalSearchQuery.page = event;
     this.getUserProjects(this.internalSearchQuery);
     return;
   }

--- a/src/app/modules/user/user.module.ts
+++ b/src/app/modules/user/user.module.ts
@@ -12,10 +12,10 @@ import { ProjectModule } from 'src/app/modules/project/project.module';
     UserProjectsComponent
   ],
   imports: [
-    CommonModule,
-    UserRoutingModule,
-    ProjectModule,
-    FormsModule
+      CommonModule,
+      UserRoutingModule,
+      ProjectModule,
+      FormsModule,
   ]
 })
 export class UserModule {

--- a/src/app/modules/user/user.module.ts
+++ b/src/app/modules/user/user.module.ts
@@ -3,7 +3,8 @@ import { UserRoutingModule } from './user-routing.module';
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { PaginationModule } from 'ngx-bootstrap/pagination';
 import { ProjectModule } from 'src/app/modules/project/project.module';
 
 
@@ -12,11 +13,13 @@ import { ProjectModule } from 'src/app/modules/project/project.module';
     UserProjectsComponent
   ],
   imports: [
-      CommonModule,
-      UserRoutingModule,
-      ProjectModule,
-      FormsModule,
-  ]
+        CommonModule,
+        UserRoutingModule,
+        ProjectModule,
+        FormsModule,
+        PaginationModule,
+        ReactiveFormsModule,
+    ]
 })
 export class UserModule {
 }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -19,10 +19,9 @@ import { HttpBaseService } from './http-base.service';
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { from, Observable, pipe } from 'rxjs';
+import { from, Observable } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { API_CONFIG } from 'src/app/config/api-config';
-import { Project } from 'src/app/models/domain/project';
 import { User } from 'src/app/models/domain/user';
 import { InternalSearchQuery } from 'src/app/models/resources/internal-search-query';
 import { SearchResultsResource } from 'src/app/models/resources/search-results';

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -17,20 +17,22 @@
 
 import { HttpBaseService } from './http-base.service';
 
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { from, Observable } from 'rxjs';
+import { from, Observable, pipe } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { API_CONFIG } from 'src/app/config/api-config';
 import { Project } from 'src/app/models/domain/project';
 import { User } from 'src/app/models/domain/user';
+import { InternalSearchQuery } from 'src/app/models/resources/internal-search-query';
+import { SearchResultsResource } from 'src/app/models/resources/search-results';
 import { UserAdd } from 'src/app/models/resources/user-add';
+
 
 @Injectable({
   providedIn: 'root',
 })
 export class UserService extends HttpBaseService<User, UserAdd, User> {
-
   constructor(http: HttpClient) {
     super(http, API_CONFIG.url + API_CONFIG.userRoute);
   }
@@ -39,25 +41,44 @@ export class UserService extends HttpBaseService<User, UserAdd, User> {
     return this.http.get<User>(this.url);
   }
 
-  public getProjectsFromUser(): Observable<Project[]> {
-    return this.http.get<Project[]>(`${this.url}/projects`)
-        .pipe(
-        mergeMap(result => from(
-            this.addLikes(result)
-        ))
-    );
+  public getProjectsFromUser(): Observable<SearchResultsResource> {
+    return this.http.get<SearchResultsResource>(`${this.url}/projects`).pipe(mergeMap((result) => from(this.addLikes(result))));
   }
 
-  private addLikes(projects): Promise<Project[]> {
-    return new Promise(resolve => {
-      this.getCurrentUser().subscribe(currentUser => {
-        projects.map(project => {
+  private addLikes(projects): Promise<SearchResultsResource> {
+    return new Promise((resolve) => {
+      this.getCurrentUser().subscribe((currentUser) => {
+        projects.results.map((project) => {
           project.likeCount = project.likes.length ? project.likes.length : 0;
-          project.userHasLikedProject = project.likes.filter(like => like.userId === currentUser?.id).length > 0;
+          project.userHasLikedProject = project.likes.filter((like) => like.userId === currentUser?.id).length > 0;
           return project;
         });
         resolve(projects);
       });
     });
+  }
+
+  public getProjectsPaginated(internalSearchQuery: InternalSearchQuery): Observable<SearchResultsResource> {
+    const url = `${this.url}/projects`;
+    let params = new HttpParams();
+
+    for (const key of Object.keys(internalSearchQuery)) {
+       if (internalSearchQuery[key] == null) {
+         continue;
+       }
+       if (Array.isArray(internalSearchQuery[key])) {
+         internalSearchQuery[key].forEach((item, index) => {
+           params = params.append(key + '[' + index + ']', item);
+         });
+       } else {
+         params = params.append(key, internalSearchQuery[key]);
+       }
+     }
+
+    return this.http
+      .get<SearchResultsResource>(url, {
+        params,
+      })
+      .pipe(mergeMap((result) => from(this.addLikes(result))));
   }
 }


### PR DESCRIPTION
## Description

I have added pagination to the user projects page, also I added filters to sort the projects.

The Modal helper utility class is now being used when opening a modal.
## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I updated the changelog with an end-user readable description
-   [x] I assigned this pull request to the correct project board to update the sprint board

## Steps to Test or Reproduce
Make sure to have the backend Repo cloned for the Get User projects endpoint, you can find it here: https://github.com/DigitalExcellence/dex-backend/tree/feature/461-add-pagination-getuserprojects-endpoint

Run DeX, after that log in as Bob.

Go to own projects page,
as you can see there is the pagination added.

## Link to issue
https://github.com/DigitalExcellence/dex-frontend/issues/526
Closes: #526 
